### PR TITLE
Style version picker and extract methods

### DIFF
--- a/src/pages/versions/compare_page.cr
+++ b/src/pages/versions/compare_page.cr
@@ -5,27 +5,32 @@ class Versions::ComparePage < MainLayout
 
   def content
     form(method: "GET", class: "pb-4 space-y-2 text-lg text-center", action: Home::Index.path) do
-      select_tag name: "from", class: "border rounded pr-2" do
-        Version::SUPPORTED_VERSIONS.each do |version|
-          option version, attrs: [version == from ? :selected : nil].compact
-        end
-      end
-
-      span class: "px-4" do
-        raw("&#8594;")
-      end
-
-      select_tag name: "to", class: "border rounded pr-2" do
-        Version::SUPPORTED_VERSIONS.each do |version|
-          option version, attrs: [version == to ? :selected : nil].compact
-        end
-      end
-
-      div do
-        submit("Compare", class: "w-40 border rounded cursor-pointer")
-      end
+      version_picker(input_name: "from", selected_version: from)
+      arrow_icon
+      version_picker(input_name: "to", selected_version: to)
+      compare_button
     end
 
     div "Loading diff...", data_controller: "diff-to-html", data_diff_to_html_unified_diff: diff
+  end
+
+  def version_picker(*, input_name, selected_version)
+    select_tag input_name: input_name, class: "border rounded pr-2" do
+      Version::SUPPORTED_VERSIONS.each do |version|
+        option version, attrs: [version == selected_version ? :selected : nil].compact
+      end
+    end
+  end
+
+  def arrow_icon
+    span class: "px-4" do
+      raw("&#8594;")
+    end
+  end
+
+  def compare_button
+    div do
+      submit("Compare", class: "w-40 border py-1 rounded border-teal-700 mt-2 cursor-pointer bg-teal-500 hover:bg-teal-600 text-white")
+    end
   end
 end


### PR DESCRIPTION
Hi Stephen!

While looking around I had some ideas for extracting methods on the page to make it easier to scan and make it easier to update the version picker. I also did some small styling tweaks.

Feel free to close or go a different direction though! 

<img width="1188" alt="Screen Shot 2020-06-22 at 11 37 08 AM" src="https://user-images.githubusercontent.com/22394/85306718-e3dbd200-b47c-11ea-8250-9bdce63cc1c2.png">
